### PR TITLE
Actually send file contents when using FHOST_USE_X_ACCEL_REDIRECT

### DIFF
--- a/fhost.py
+++ b/fhost.py
@@ -282,7 +282,7 @@ def get(path):
             fsize = os.path.getsize(fpath)
 
             if app.config["FHOST_USE_X_ACCEL_REDIRECT"]:
-                response = make_response()
+                response = make_response(open(fpath, "r").read(), 200)
                 response.headers["Content-Type"] = f.mime
                 response.headers["Content-Length"] = fsize
                 response.headers["X-Accel-Redirect"] = "/" + fpath


### PR DESCRIPTION
When I try to run 0x0 with the default settings, by going `python3 fhost.py runserver`, and using `FHOST_USE_X_ACCEL_REDIRECT` in the state of `True`, it allows me to upload files. However, when I try to `curl`, those files, it throws errors such as this:

```
curl: (18) transfer closed with 34767 bytes remaining to read
```

This is because it isn't actually sending the file contents! The edit to the code I make causes the server to function normally and actually send the file over without issue.